### PR TITLE
feat: support libc field checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Errors have a `required` and `current` fields.
 
 ### .checkEngine(pkg, npmVer, nodeVer, force = false)
 
-Check if node/npm version is supported by the package. If it isn't
-supported, an error is thrown.
+Check if a package's `engines.node` and `engines.npm` match the running system.
 
 `force` argument will override the node version check, but not the npm
 version check, as this typically would indicate that the current version of
@@ -22,6 +21,8 @@ Error code: 'EBADENGINE'
 
 ### .checkPlatform(pkg, force)
 
-Check if OS/Arch is supported by the package.
+Check if a package's `os`, `cpu` and `libc` match the running system.
+
+`force` argument skips all checks.
 
 Error code: 'EBADPLATFORM'

--- a/test/check-platform.js
+++ b/test/check-platform.js
@@ -42,3 +42,81 @@ t.test('os wrong (negation)', async t =>
 
 t.test('nothing wrong (negation)', async t =>
   checkPlatform({ cpu: '!enten-cpu', os: '!enten-os' }))
+
+t.test('libc', (t) => {
+  let PLATFORM = ''
+
+  const _processPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', {
+    enumerable: true,
+    configurable: true,
+    get: () => PLATFORM,
+  })
+
+  let REPORT = {}
+  const _processReport = process.report.getReport
+  process.report.getReport = () => REPORT
+
+  t.teardown(() => {
+    Object.defineProperty(process, 'platform', _processPlatform)
+    process.report.getReport = _processReport
+  })
+
+  t.test('fails when not in linux', (t) => {
+    PLATFORM = 'darwin'
+
+    t.throws(() => checkPlatform({ libc: 'glibc' }), { code: 'EBADPLATFORM' },
+      'fails for glibc when not in linux')
+    t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
+      'fails for musl when not in linux')
+    t.end()
+  })
+
+  t.test('glibc', (t) => {
+    PLATFORM = 'linux'
+
+    REPORT = {}
+    t.throws(() => checkPlatform({ libc: 'glibc' }), { code: 'EBADPLATFORM' },
+      'fails when report is missing header property')
+
+    REPORT = { header: {} }
+    t.throws(() => checkPlatform({ libc: 'glibc' }), { code: 'EBADPLATFORM' },
+      'fails when header is missing glibcRuntimeVersion property')
+
+    REPORT = { header: { glibcRuntimeVersion: '1' } }
+    t.doesNotThrow(() => checkPlatform({ libc: 'glibc' }), 'allows glibc on glibc')
+    t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
+      'does not allow musl on glibc')
+
+    t.end()
+  })
+
+  t.test('musl', (t) => {
+    PLATFORM = 'linux'
+
+    REPORT = {}
+    t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
+      'fails when report is missing sharedObjects property')
+
+    REPORT = { sharedObjects: {} }
+    t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
+      'fails when sharedObjects property is not an array')
+
+    REPORT = { sharedObjects: [] }
+    t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
+      'fails when sharedObjects does not contain musl')
+
+    REPORT = { sharedObjects: ['ld-musl-foo'] }
+    t.doesNotThrow(() => checkPlatform({ libc: 'musl' }), 'allows musl on musl as ld-musl-')
+
+    REPORT = { sharedObjects: ['libc.musl-'] }
+    t.doesNotThrow(() => checkPlatform({ libc: 'musl' }), 'allows musl on musl as libc.musl-')
+
+    t.throws(() => checkPlatform({ libc: 'glibc' }), { code: 'EBADPLATFORM' },
+      'does not allow glibc on musl')
+
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
this implements support for matching the `libc` field as part of `checkPlatform`

follow up: after this lands we'll want to update the error messaging for the `EBADPLATFORM` error code in the cli to account for the new fields

for npm/rfcs#438
