### PR TITLE
fix: typo glibcRuntimeVersion glibcVersionRuntime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ const checkPlatform = (target, force = false) => {
       libcOk = false
     } else {
       const report = process.report.getReport()
-      if (report.header?.glibcRuntimeVersion) {
+      if (report.header?.glibcVersionRuntime) {
         libcFamily = 'glibc'
       } else if (Array.isArray(report.sharedObjects) && report.sharedObjects.some(isMusl)) {
         libcFamily = 'musl'

--- a/test/check-platform.js
+++ b/test/check-platform.js
@@ -81,9 +81,9 @@ t.test('libc', (t) => {
 
     REPORT = { header: {} }
     t.throws(() => checkPlatform({ libc: 'glibc' }), { code: 'EBADPLATFORM' },
-      'fails when header is missing glibcRuntimeVersion property')
+      'fails when header is missing glibcVersionRuntime property')
 
-    REPORT = { header: { glibcRuntimeVersion: '1' } }
+    REPORT = { header: { glibcVersionRuntime: '1' } }
     t.doesNotThrow(() => checkPlatform({ libc: 'glibc' }), 'allows glibc on glibc')
     t.throws(() => checkPlatform({ libc: 'musl' }), { code: 'EBADPLATFORM' },
       'does not allow musl on glibc')


### PR DESCRIPTION
cc @nlf @wraithgar I think this was a typo introduced in https://github.com/npm/npm-install-checks/pull/54 and the correct header is `glibcVersionRuntime`  as seen here: https://github.com/search?q=org%3Anodejs+glibcVersionRuntime&type=code

```
bash-4.2# npm i npm-install-checks
+ npm-install-checks@6.1.0
added 4 packages from 3 contributors and audited 4 packages in 0.83s
found 0 vulnerabilities

bash-4.2# node -e "require('npm-install-checks').checkPlatform({libc:'glibc'})"
/foo/node_modules/npm-install-checks/lib/index.js:53
    throw Object.assign(new Error('Unsupported platform'), {
    ^

Error: Unsupported platform
    at Object.checkPlatform (/foo/node_modules/npm-install-checks/lib/index.js:53:25)
    at [eval]:1:31
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:313:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60)
    at node:internal/main/eval_string:27:3 {
  pkgid: undefined,
  current: { os: 'linux', cpu: 'x64', libc: null },
  required: { os: undefined, cpu: undefined, libc: 'glibc' },
  code: 'EBADPLATFORM'
}

bash-4.2# patch -u node_modules/npm-install-checks/lib/index.js pr57.patch 
patching file node_modules/npm-install-checks/lib/index.js

bash-4.2# node -e "require('npm-install-checks').checkPlatform({libc:'glibc'})"
bash-4.2# echo $?
0
```