### PR TITLE
feat: allow checkPlatform to override execution environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ npm is unable to install the package properly for some reason.
 
 Error code: 'EBADENGINE'
 
-### .checkPlatform(pkg, force)
+### .checkPlatform(pkg, force, environment)
 
 Check if a package's `os`, `cpu` and `libc` match the running system.
 
 `force` argument skips all checks.
+
+`environment` overrides the execution environment which comes from `process.platform` and `process.arch` by default. `environment.os` and `environment.cpu` are available.
+
+```js
 
 Error code: 'EBADPLATFORM'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,4 @@ Check if a package's `os`, `cpu` and `libc` match the running system.
 
 `environment` overrides the execution environment which comes from `process.platform` and `process.arch` by default. `environment.os` and `environment.cpu` are available.
 
-```js
-
 Error code: 'EBADPLATFORM'

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,8 +27,8 @@ const checkPlatform = (target, force = false, environment = {}) => {
     return
   }
 
-  const platform = environment && environment.os ? environment.os : process.platform
-  const arch = environment && environment.cpu ? environment.cpu : process.arch
+  const platform = environment.os || process.platform
+  const arch = environment.cpu || process.arch
   const osOk = target.os ? checkList(platform, target.os) : true
   const cpuOk = target.cpu ? checkList(arch, target.cpu) : true
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,13 +22,13 @@ const checkEngine = (target, npmVer, nodeVer, force = false) => {
 
 const isMusl = (file) => file.includes('libc.musl-') || file.includes('ld-musl-')
 
-const checkPlatform = (target, force = false) => {
+const checkPlatform = (target, force = false, environment = {}) => {
   if (force) {
     return
   }
 
-  const platform = process.platform
-  const arch = process.arch
+  const platform = environment && environment.os ? environment.os : process.platform
+  const arch = environment && environment.cpu ? environment.cpu : process.arch
   const osOk = target.os ? checkList(platform, target.os) : true
   const cpuOk = target.cpu ? checkList(arch, target.cpu) : true
 

--- a/test/check-platform.js
+++ b/test/check-platform.js
@@ -43,6 +43,38 @@ t.test('os wrong (negation)', async t =>
 t.test('nothing wrong (negation)', async t =>
   checkPlatform({ cpu: '!enten-cpu', os: '!enten-os' }))
 
+t.test('nothing wrong with overridden os', async t =>
+  checkPlatform({
+    cpu: 'any',
+    os: 'enten-os',
+  }, false, {
+    os: 'enten-os',
+  }))
+
+t.test('nothing wrong with overridden cpu', async t =>
+  checkPlatform({
+    cpu: 'enten-cpu',
+    os: 'any',
+  }, false, {
+    cpu: 'enten-cpu',
+  }), { code: 'EBADPLATFORM' })
+
+t.test('wrong os with overridden os', async t =>
+  t.throws(() => checkPlatform({
+    cpu: 'any',
+    os: 'enten-os',
+  }, false, {
+    os: 'another-os',
+  }), { code: 'EBADPLATFORM' }))
+
+t.test('wrong cpu with overridden cpu', async t =>
+  t.throws(() => checkPlatform({
+    cpu: 'enten-cpu',
+    os: 'any',
+  }, false, {
+    cpu: 'another-cpu',
+  }), { code: 'EBADPLATFORM' }))
+
 t.test('libc', (t) => {
   let PLATFORM = ''
 

--- a/test/check-platform.js
+++ b/test/check-platform.js
@@ -57,7 +57,7 @@ t.test('nothing wrong with overridden cpu', async t =>
     os: 'any',
   }, false, {
     cpu: 'enten-cpu',
-  }), { code: 'EBADPLATFORM' })
+  }))
 
 t.test('wrong os with overridden os', async t =>
   t.throws(() => checkPlatform({


### PR DESCRIPTION
<!-- What / Why -->

This PR allows `checkPlatform` to override execution environment which comes from `process.platform` and `process.arch` by default.

<!-- Describe the request in detail. What it does and why it's being changed. -->

This will be required to achieve https://github.com/npm/rfcs/issues/612

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
