### PR TITLE
fix: skip network requests in report.getReport()

### DIFF
--- a/lib/current-env.js
+++ b/lib/current-env.js
@@ -19,7 +19,10 @@ function libc (osName) {
     return undefined
   }
   let family
+  const originalExclude = process.report.excludeNetwork
+  process.report.excludeNetwork = true
   const report = process.report.getReport()
+  process.report.excludeNetwork = originalExclude
   if (report.header?.glibcVersionRuntime) {
     family = 'glibc'
   } else if (Array.isArray(report.sharedObjects) && report.sharedObjects.some(isMusl)) {


### PR DESCRIPTION
It is very slow in win32 environments and we don't need that info here

Closes: https://github.com/npm/npm-install-checks/issues/95
