### PR TITLE
fix: cache family when calling libc()

### DIFF
--- a/lib/current-env.js
+++ b/lib/current-env.js
@@ -13,12 +13,16 @@ function cpu () {
   return process.arch
 }
 
+let family
+
 function libc (osName) {
   // this is to make it faster on non linux machines
   if (osName !== 'linux') {
     return undefined
   }
-  let family
+  if (family) {
+    return family
+  }
   const originalExclude = process.report.excludeNetwork
   process.report.excludeNetwork = true
   const report = process.report.getReport()


### PR DESCRIPTION
We can assume that the same process will return the same report and thus we can cache the resulting family in memory to make it faster for subsequent invocations.

For example, this function is called in a loop here:
https://github.com/npm/cli/blob/780afc50e3a345feb1871a28e33fa48235bc3bd5/workspaces/arborist/lib/arborist/build-ideal-tree.js#L212

## References
Fixes https://github.com/npm/npm-install-checks/pull/116#discussion_r1819321514
