### PR TITLE
fix(current-env): freezing when calling current env

### DIFF
--- a/lib/current-env.js
+++ b/lib/current-env.js
@@ -1,9 +1,6 @@
 const process = require('node:process')
 const nodeOs = require('node:os')
-
-function isMusl (file) {
-  return file.includes('libc.musl-') || file.includes('ld-musl-')
-}
+const { familySync } = require('detect-libc')
 
 function os () {
   return process.platform
@@ -13,22 +10,8 @@ function cpu () {
   return process.arch
 }
 
-function libc (osName) {
-  // this is to make it faster on non linux machines
-  if (osName !== 'linux') {
-    return undefined
-  }
-  let family
-  const originalExclude = process.report.excludeNetwork
-  process.report.excludeNetwork = true
-  const report = process.report.getReport()
-  process.report.excludeNetwork = originalExclude
-  if (report.header?.glibcVersionRuntime) {
-    family = 'glibc'
-  } else if (Array.isArray(report.sharedObjects) && report.sharedObjects.some(isMusl)) {
-    family = 'musl'
-  }
-  return family
+function libc () {
+  return familySync() || undefined
 }
 
 function devEngines (env = {}) {
@@ -38,7 +21,7 @@ function devEngines (env = {}) {
       name: env.cpu || cpu(),
     },
     libc: {
-      name: env.libc || libc(osName),
+      name: env.libc || libc(),
     },
     os: {
       name: osName,

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Check the engines and platform fields in package.json",
   "main": "lib/index.js",
   "dependencies": {
+    "detect-libc": "^2.0.3",
     "semver": "^7.1.1"
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^5.0.0",
     "@npmcli/template-oss": "4.23.3",
+    "rewiremock": "^3.14.5",
     "tap": "^16.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Related https://github.com/npm/npm-install-checks/pull/121
Related https://github.com/npm/npm-install-checks/pull/120

This PR basically avoid calling `getReport` that is well-known for being slow on linux machines with multiple cores (https://github.com/nodejs/node/issues/48831), and also avoid a bug in the `excludeNetwork` fixed on https://github.com/nodejs/node/pull/55602.

From my tests, the issue with CPU didn't impact the performance, but the `excludeNetwork`, fixed in the 55602, was the principal issue that was slowing down the `npm install`.

Instead of copying the code from `detect-libc`, I prefer to just import the library which has been very well tested.