### PR TITLE
Sort versions object inside thrown error object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ const checkEngine = (target, npmVer, nodeVer, force = false) => {
     throw Object.assign(new Error('Unsupported engine'), {
       pkgid: target._id,
       current: { node: nodeVer, npm: npmVer },
-      required: eng,
+      required: Object.fromEntries(Object.entries(eng).sort()),
       code: 'EBADENGINE',
     })
   }


### PR DESCRIPTION
<!-- What / Why -->

I got this error message in my console once:

> npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'react-webapp@0.1.0',
npm warn EBADENGINE   required: { npm: '10.X', node: '20.X' },
npm warn EBADENGINE   current: { node: 'v25.6.1', npm: '11.18.0' }
npm warn EBADENGINE }

and I disliked how the order is inconsistent between the `required` and `current` lines.

In this quick PR I am making `required`'s value a sorted object -- by creating an array of entries, sorting it, then creating a new object from that.  (I first wanted to use `toSorted`, but that probably won't work on node v19)